### PR TITLE
chore: Add templ watch files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp
 
 # Ignore compiled templ files
 internal/web/**/*_templ.go
+internal/web/**/*_templ.txt


### PR DESCRIPTION
Execution of `templ generate --watch` creates:
```bash
        internal/web/templ/components/error_templ.txt
        internal/web/templ/components/modal_add_note_templ.txt
        internal/web/templ/components/modal_edit_note_templ.txt
        internal/web/templ/components/modal_form_templ.txt
        internal/web/templ/components/note_templ.txt
        internal/web/templ/page/index_templ.txt
        internal/web/templ/view/notFound_templ.txt
        internal/web/templ/view/notesView_templ.txt
```