### PR TITLE
chore: Bump htmx

### DIFF
--- a/internal/web/templ/page/index.templ
+++ b/internal/web/templ/page/index.templ
@@ -7,8 +7,8 @@ templ Index(body templ.Component) {
             <meta charset="UTF-8"/>
             <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
             <meta name="viewport" content="width=device-width, initial-scale=1"/>
-            <script src="https://unpkg.com/htmx.org@1.9.12"></script>
-            <script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/response-targets.js"></script>
+            <script src="https://unpkg.com/htmx.org@2.0.0"></script>
+            <script src="https://unpkg.com/htmx-ext-response-targets@2.0.0/response-targets.js"></script>
             <link href="https://cdn.jsdelivr.net/npm/@picocss/pico@next/css/pico.min.css" rel="stylesheet"/>
             <script type="module" src="https://unpkg.com/ionicons@7.3.1/dist/ionicons/ionicons.esm.js"></script>
             <link href="/static/custom.css" rel="stylesheet"/>


### PR DESCRIPTION
[htmx 2.0.0](https://github.com/bigskysoftware/htmx/releases/tag/v2.0.0) has been released